### PR TITLE
update default formatting to location values and bedding values

### DIFF
--- a/mk_sam_file.py
+++ b/mk_sam_file.py
@@ -262,7 +262,7 @@ def main():
             #         str( attribute) + ' is a requred numeric value'
             # set default bedding strike and dip to 0 if user did not supply
             if (attribute =='bedding_strike') and (math.isnan(float(df[sample][attribute]))):
-                df[sample][attribute] = 0.0
+                df[sample][attribute] = 90.0
             if (attribute =='bedding_dip') and (math.isnan(float(df[sample][attribute]))):
                 df[sample][attribute] = 0.0
             if attribute == 'bedding_strike' and \

--- a/mk_sam_file.py
+++ b/mk_sam_file.py
@@ -169,10 +169,12 @@ def main():
     # creating long lat and dec info
     for value in site_values:
         hdf['site_info'][value] = str(round(float(hdf['site_info'][value]), 1))
+        # format latitude values
         if value == 'site_lat':
             sam_header += ' ' + hdf['site_info'][value]
-        else:
-            sam_header += ' '*(5-len(hdf['site_info'][value]) + 1) + hdf['site_info'][value]
+            # format longitude values and force to 0-360
+        if value == 'site_long':
+            sam_header += ' {:05.1f}'.format(float(hdf['site_info'][value])%360)
     sam_header += ' '*(3) + '0.0'
     sam_header += '\r\n'
 
@@ -258,6 +260,11 @@ def main():
         for attribute in attributes:
             # assert (str(df[sample][attribute]).isdigit()),\
             #         str( attribute) + ' is a requred numeric value'
+            # set default bedding strike and dip to 0 if user did not supply
+            if (attribute =='bedding_strike') and (math.isnan(float(df[sample][attribute]))):
+                df[sample][attribute] = 0.0
+            if (attribute =='bedding_dip') and (math.isnan(float(df[sample][attribute]))):
+                df[sample][attribute] = 0.0
             if attribute == 'bedding_strike' and \
                         ((df[sample]['correct_bedding_using_local_dec']) == 'yes' or
                          (df[sample]['correct_bedding_using_local_dec']) == 'Yes' or


### PR DESCRIPTION
I added in the code 2 formatting related features:
1. in .sam files, we now force the longitude values to be positive numbers (eastward). Previously we just used whatever users input. But the negative sign will take the space between the lat and long values and result in both the magnetometer software to incorrectly read the file and cause error in MagIC file conversion in PmagGui. 
2. in specimen files, we now set the default values for bedding strike and bedding dip to be 0.0 when users do not specify the values in the .csv files. Previously these values would be empty in the specimen file when user did not put in values. This caused issues during conversion to MagIC files.